### PR TITLE
Fix `ktor-server-kafka` README

### DIFF
--- a/ktor-server-kafka/README.md
+++ b/ktor-server-kafka/README.md
@@ -24,7 +24,7 @@ The plugin provides a DSL that enables comprehensive Kafka configuration, adheri
 
 ```kotlin
 install(Kafka) {
-    schemaRegistryUrl = listOf("my.schemaRegistryUrl")
+    schemaRegistryUrl = "my.schemaRegistryUrl"
      topic(named("my-topic")) {
          partitions = 1
          replicas = 1


### PR DESCRIPTION
This commit fixes a small mistake in the ktor-server-kafka plugin where the schema registry URL was expecting a list of strings, while the actual implementation accepts only a single string.