### PR TITLE
Taskscheduling mongodb and redis based integration tests fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ out/
 .actrc
 /.run/publish all to local.run.xml
 /.run/publish kafka and run example.run.xml
+/.kotlin
+/buildSrc/.kotlin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ java = "11"
 kotlinx-serialization = "1.7.3"
 kotlinx-io = "0.3.0"
 ksp = "1.9.10-1.0.13"
+reactor = "3.7.4"
 
 # Web Framework
 ktor = "3.0.0"
@@ -60,6 +61,8 @@ avro = "1.12.0"
 # Redis
 kreds = "0.9.1"
 redis-mp-client = "0.0.3"
+microutils = "3.0.5" # required for kreds lib that doesn't expose via api() - https://github.com/crackthecodeabhi/kreds/blob/main/build.gradle.kts#L74-L76
+netty = "4.1.104.Final" # required for kreds lib that doesn't expose via api() - https://github.com/crackthecodeabhi/kreds/blob/main/build.gradle.kts#L74-L76
 
 # Documentation
 dokka = "1.9.10"
@@ -82,10 +85,12 @@ arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref 
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactor" }
 
 # Web Framework
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
@@ -188,6 +193,9 @@ gradle-release-gradlePlugin = { module = "net.researchgate:gradle-release", vers
 krontab = { module = "dev.inmo:krontab", version.ref = "krontab" }
 uuid = { module = "com.benasher44:uuid", version.ref = "uuid" }
 kreds = { module = "io.github.crackthecodeabhi:kreds", version.ref = "kreds" }
+microutils-logging = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "microutils" }
+netty-codec-redis = { module = "io.netty:netty-codec-redis", version.ref = "netty" }
+netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
 redis-mp-client = { module = "io.github.flaxoos:redis-client-multiplatform", version.ref = "redis-mp-client" }
 
 [plugins]

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-mongodb/build.gradle.kts
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-mongodb/build.gradle.kts
@@ -14,6 +14,8 @@ kotlin {
             api(projects.ktorServerTaskScheduling.ktorServerTaskSchedulingCore)
             api(libs.mongodb.driver.kotlin.coroutine)
             api(libs.mongodb.bson.kotlinx)
+            api(libs.reactor.core)
+            implementation(libs.kotlinx.coroutines.reactive)
         }
         jvmTestDependencies {
             implementation(projects.ktorServerTaskScheduling.ktorServerTaskSchedulingCore.test)

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-redis/build.gradle.kts
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-redis/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
             implementation(libs.mockk)
             implementation(libs.testcontainers.redis)
             implementation(libs.kreds)
+            implementation(libs.microutils.logging)
+            implementation(libs.netty.handler)
+            implementation(libs.netty.codec.redis)
         }
         nativeMainDependencies {
             api(projects.common)


### PR DESCRIPTION
Relates to #85, this is an attempt to break out that massive PR into smaller chunks, starting with the changes required to resolve the integration test errors on the current main branch described in this [comment](https://github.com/Flaxoos/extra-ktor-plugins/pull/85#issuecomment-2737268044).

This PR makes the following changes:
- adds missing reactor-core dependency in the mongodb based plugin which is required to build and run the module and tests
(https://github.com/crackthecodeabhi/kreds/blob/main/build.gradle.kts#L74-L76) as `api` instead of `implementation`.
- adds serialization codec for the `MongoDbTaskLock` class required to build and run the mongo based plugin tests
-  adds missing transitive dependencies required by the `kreds` test dependency in the redis based plugin which is a result of the `kreds` gradle file not specifying these [dependencies]