### PR TITLE
feat(task-scheduler): #98: Add an in-memory TaskManager implementation 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,24 +80,39 @@ jobs:
 
       - name: Generate Version
         id: version
+        shell: bash
         run: |
+          set -euo pipefail
+
           RELEASE_TYPE="${{ steps.release-context.outputs.release_type }}"
+          echo "Release type: $RELEASE_TYPE"
 
           if [[ "$RELEASE_TYPE" == "snapshot" ]]; then
             echo "🔄 Creating snapshot version"
-            # Use snapshot mode
-            VERSION=$(./gradlew -q currentVersion -Prelease.mode=snapshot)
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+            RAW_VERSION="$(./gradlew -q currentVersion -Prelease.mode=snapshot)"
+            IS_SNAPSHOT=true
           else
             echo "🚀 Creating release version"
-            # Use release mode
-            VERSION=$(./gradlew -q currentVersion -Prelease.mode=release)
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+            RAW_VERSION="$(./gradlew -q currentVersion -Prelease.mode=release)"
+            IS_SNAPSHOT=false
           fi
 
+          # Extract the actual version if Gradle prints "Project version: X"
+          VERSION="$(echo "$RAW_VERSION" | sed -E 's/^[Pp]roject version:[[:space:]]*//')"
+          # Strip CR just in case
+          VERSION="${VERSION//$'\r'/}"
+
           echo "Final version: $VERSION"
+
+          # Escape characters per GitHub docs
+          SAFE_VERSION="${VERSION//'%'/'%25'}"
+          SAFE_VERSION="${SAFE_VERSION//$'\n'/'%0A'}"
+          SAFE_VERSION="${SAFE_VERSION//$'\r'/'%0D'}"
+
+          {
+            echo "version=$SAFE_VERSION"
+            echo "is_snapshot=$IS_SNAPSHOT"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/TaskSchedulerPlugin.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/TaskSchedulerPlugin.kt
@@ -27,6 +27,9 @@ public val TaskScheduling: ApplicationPlugin<TaskSchedulingConfiguration> =
     ) {
         application.log.debug("Configuring TaskScheduler")
 
+        // Ensure a default task manager exists if none were configured
+        pluginConfig.ensureDefaultTaskManager()
+
         checkUniqueTaskNames()
 
         val taskManagers = createTaskManagers()
@@ -72,11 +75,8 @@ private fun PluginBuilder<TaskSchedulingConfiguration>.checkTaskMangerAssignment
     }
 }
 
-private fun PluginBuilder<TaskSchedulingConfiguration>.createTaskManagers(): List<TaskManager<*>> {
-    val taskManagers = pluginConfig.taskManagers.map { createTaskManager -> createTaskManager(application) }
-    require(taskManagers.isNotEmpty()) { "No task managers were configured" }
-    return taskManagers
-}
+private fun PluginBuilder<TaskSchedulingConfiguration>.createTaskManagers(): List<TaskManager<*>> =
+    pluginConfig.taskManagers.map { createTaskManager -> createTaskManager(application) }
 
 private fun PluginBuilder<TaskSchedulingConfiguration>.checkUniqueTaskNames() {
     with(

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/TaskSchedulingConfiguration.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/TaskSchedulingConfiguration.kt
@@ -6,6 +6,7 @@ import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManager
 import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration
 import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration.TaskManagerName
 import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration.TaskManagerName.Companion.toTaskManagerName
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.inmemory.InMemoryLockManagerConfiguration
 import io.github.flaxoos.ktor.server.plugins.taskscheduling.tasks.Task
 import io.ktor.server.application.Application
 import korlibs.time.DateTime
@@ -54,6 +55,16 @@ public open class TaskSchedulingConfiguration {
     public fun addTaskManager(taskManagerConfiguration: TaskManagerConfiguration) {
         taskManagers.add {
             taskManagerConfiguration.createTaskManager(it)
+        }
+    }
+
+    /**
+     * Ensure a default task manager is available if none were configured.
+     * This is called internally by the plugin.
+     */
+    internal fun ensureDefaultTaskManager() {
+        if (taskManagers.isEmpty()) {
+            addTaskManager(InMemoryLockManagerConfiguration())
         }
     }
 }

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManager.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManager.kt
@@ -1,0 +1,239 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.inmemory
+
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingConfiguration
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingDsl
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration.TaskManagerName.Companion.toTaskManagerName
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueStore
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueTaskLockManager
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueTaskLockManagerConfiguration
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.Application
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.datetime.Clock
+import kotlin.random.Random
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * An in-memory implementation of [KeyValueTaskLockManager].
+ *
+ * This implementation is suitable for single-instance deployments where distributed locking
+ * is not required. All locks are stored in memory and will be lost on application restart.
+ *
+ * **Important**: This manager provides locking within a single JVM/process across all
+ * InMemoryLockManager instances. It does NOT provide distributed locking across separate
+ * JVM processes or machines.
+ *
+ * @property name The name of the task manager
+ * @property application The Ktor application instance
+ * @property lockExpirationMs Lock expiration time in milliseconds. Locks older than this
+ *           duration will be considered expired and can be re-acquired.
+ * @property maxSize Maximum number of entries allowed in memory before forced cleanup.
+ *           Default: 10,000 entries
+ * @property cleanupProbability Probability (0-100) of triggering cleanup on each setIfNotExist call.
+ *           Higher values = more frequent cleanup but slightly slower performance. Default: 10 (10%)
+ */
+public class InMemoryLockManager(
+    override val name: TaskManagerConfiguration.TaskManagerName,
+    override val application: Application,
+    lockExpirationMs: Long,
+    maxSize: Int = 10_000,
+    cleanupProbability: Int = 10,
+) : KeyValueTaskLockManager(lockExpirationMs) {
+    override val store: KeyValueStore = InMemoryKeyValueStore(maxSize, cleanupProbability)
+
+    override fun close() {
+        val kvStore = store as InMemoryKeyValueStore
+        logger.debug { "Closing InMemoryLockManager, clearing ${kvStore.size()} locks" }
+        kvStore.clear()
+    }
+}
+
+/**
+ * Configuration for [InMemoryLockManager]
+ */
+@TaskSchedulingDsl
+public class InMemoryLockManagerConfiguration : KeyValueTaskLockManagerConfiguration() {
+    /**
+     * Lock expiration time in milliseconds.
+     * Locks older than this duration will be considered expired and can be re-acquired.
+     */
+    public var lockExpirationMs: Long = 100
+
+    /**
+     * Maximum number of entries allowed in memory before forced cleanup.
+     * Default: 10,000 entries
+     */
+    public var maxSize: Int = 10_000
+
+    /**
+     * Probability (0-100) of triggering cleanup on each setIfNotExist call.
+     * Higher values = more frequent cleanup but slightly slower performance.
+     * Default: 10 (10% of calls trigger cleanup)
+     */
+    public var cleanupProbability: Int = 10
+
+    override fun createTaskManager(application: Application): InMemoryLockManager =
+        InMemoryLockManager(
+            name = name.toTaskManagerName(),
+            application = application,
+            lockExpirationMs = lockExpirationMs,
+            maxSize = maxSize,
+            cleanupProbability = cleanupProbability,
+        )
+}
+
+/**
+ * Add an [InMemoryLockManager] to the task scheduling configuration.
+ *
+ * This provides an in-memory task lock manager suitable for single-instance deployments
+ * where distributed locking is not required.
+ *
+ * **Important**: This manager provides locking within a single JVM/process across all
+ * InMemoryLockManager instances. It does NOT provide distributed locking across separate
+ * JVM processes or machines.
+ *
+ * **Memory Management**: The in-memory store uses probabilistic cleanup to prevent memory leaks
+ * from expired lock entries. Cleanup is triggered:
+ * - Always when the number of entries exceeds `maxSize`
+ * - Probabilistically on `cleanupProbability`% of lock acquisition attempts
+ *
+ * Example usage:
+ * ```kotlin
+ * install(TaskScheduling) {
+ *     inMemory {
+ *         lockExpirationMs = 60_000      // Locks expire after 60 seconds
+ *         maxSize = 10_000               // Trigger cleanup if > 10K entries
+ *         cleanupProbability = 10        // 10% chance of cleanup per call
+ *     }
+ *
+ *     task {
+ *         name = "my-task"
+ *         kronSchedule = { seconds { 0 every 30 } }
+ *         task = { executionTime ->
+ *             // Task logic here
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param name The name of the task manager. If not provided, this will be the default task manager.
+ *             Only one default task manager is allowed.
+ * @param config Configuration block for the in-memory lock manager
+ */
+@TaskSchedulingDsl
+public fun TaskSchedulingConfiguration.inMemory(
+    name: String? = null,
+    config: InMemoryLockManagerConfiguration.() -> Unit = {},
+) {
+    this.addTaskManager(
+        InMemoryLockManagerConfiguration().apply {
+            config()
+            this.name = name
+        },
+    )
+}
+
+/**
+ * In-memory implementation of [KeyValueStore] using a ConcurrentMap.
+ *
+ * This implementation provides SET-if-not-exists semantics with TTL support
+ * using a retry loop and manual expiration checking. The storage is shared
+ * across all instances within the same JVM process.
+ *
+ * **TTL and Memory Management:**
+ * - Expired entries are removed lazily when accessed (opportunistic cleanup)
+ * - Probabilistic cleanup runs on a percentage of [setIfNotExist] calls
+ * - Hard limit cleanup triggers when [maxSize] is exceeded
+ *
+ * @property maxSize Maximum entries before forced cleanup (default: 10,000)
+ * @property cleanupProbability Percentage chance (0-100) of cleanup per call (default: 10)
+ */
+internal class InMemoryKeyValueStore(
+    private val maxSize: Int = 10_000,
+    private val cleanupProbability: Int = 10,
+) : KeyValueStore {
+    private companion object {
+        // Shared storage across all InMemoryKeyValueStore instances in the same JVM
+        private val storage = ConcurrentMap<String, ExpiringValue>()
+    }
+
+    /**
+     * Internal wrapper to store values with expiration time
+     */
+    private data class ExpiringValue(
+        val value: String,
+        val expiresAtMs: Long,
+    )
+
+    override suspend fun setIfNotExist(
+        key: String,
+        value: String,
+        ttlMs: Long,
+    ): Boolean {
+        // Cleanup strategy: size-based + probabilistic
+        when {
+            // Hard limit - always cleanup if exceeded
+            storage.size > maxSize -> cleanupExpired()
+
+            // Probabilistic cleanup - amortize cost across calls
+            cleanupProbability > 0 && Random.nextInt(100) < cleanupProbability ->
+                cleanupExpired()
+        }
+
+        val now = Clock.System.now().toEpochMilliseconds()
+        val expiresAt = now + ttlMs
+
+        while (true) {
+            var wasCreated = false
+            val expiringValue = ExpiringValue(value, expiresAt)
+
+            val existing =
+                storage.computeIfAbsent(key) {
+                    wasCreated = true
+                    expiringValue
+                }
+
+            when {
+                // Successfully created new entry
+                wasCreated -> return true
+
+                // Entry exists but expired - try to replace atomically
+                now >= existing.expiresAtMs -> {
+                    storage.remove(key, existing)
+                    continue
+                }
+
+                // Entry exists and valid - failed to acquire
+                else -> return false
+            }
+        }
+    }
+
+    /**
+     * Remove all expired entries from storage.
+     * Scans entire map - O(n) operation.
+     */
+    private fun cleanupExpired() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val iterator = storage.entries.iterator()
+
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (now >= entry.value.expiresAtMs) {
+                iterator.remove()
+            }
+        }
+    }
+
+    /**
+     * Clear all entries from the store
+     */
+    fun clear(): Unit = storage.clear()
+
+    /**
+     * Get the number of entries in the store
+     */
+    fun size(): Int = storage.size
+}

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/keyvalue/KeyValueStore.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/keyvalue/KeyValueStore.kt
@@ -1,0 +1,29 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue
+
+/**
+ * Abstraction for a key-value store with SET-if-not-exists semantics and TTL support.
+ *
+ * This interface provides a common abstraction for different key-value storage mechanisms
+ * (e.g., Redis, in-memory maps) that support atomic set-if-not-exists operations with
+ * time-to-live functionality.
+ */
+public interface KeyValueStore {
+    /**
+     * Attempt to set a key-value pair only if the key doesn't already exist,
+     * with a time-to-live in milliseconds.
+     *
+     * This operation should be atomic - either the key is set successfully (and returns true),
+     * or it already exists (and returns false). The TTL is calculated from the system clock
+     * at the time of the call.
+     *
+     * @param key The key to set
+     * @param value The value to set
+     * @param ttlMs Time-to-live in milliseconds from now
+     * @return true if the key was set successfully, false if it already exists
+     */
+    public suspend fun setIfNotExist(
+        key: String,
+        value: String,
+        ttlMs: Long,
+    ): Boolean
+}

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/keyvalue/KeyValueTaskLockManager.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/keyvalue/KeyValueTaskLockManager.kt
@@ -1,0 +1,95 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue
+
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingDsl
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManager.Companion.format2
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.TaskLockManager
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.TaskLockManagerConfiguration
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.tasks.Task
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.tasks.TaskLock
+import io.github.oshai.kotlinlogging.KotlinLogging
+import korlibs.time.DateTime
+import kotlin.jvm.JvmInline
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * An abstract implementation of [TaskLockManager] using a key-value store as the lock store
+ */
+public abstract class KeyValueTaskLockManager(
+    protected val lockExpirationMs: Long,
+) : TaskLockManager<KeyValueTaskLock>() {
+    /**
+     * The underlying key-value store implementation
+     */
+    protected abstract val store: KeyValueStore
+
+    final override suspend fun init(tasks: List<Task>) {
+        logger.debug { "Initializing ${this::class.simpleName} for ${tasks.size} tasks" }
+    }
+
+    final override suspend fun acquireLockKey(
+        task: Task,
+        executionTime: DateTime,
+        concurrencyIndex: Int,
+    ): KeyValueTaskLock? {
+        val lockKey = KeyValueTaskLock.create(task, concurrencyIndex, executionTime)
+        logger.debug {
+            "${application.host()}: ${executionTime.format2()}: Acquiring lock for ${task.name} - $concurrencyIndex"
+        }
+
+        val acquired =
+            store.setIfNotExist(
+                key = lockKey.value,
+                value = executionTime.format2(),
+                ttlMs = lockExpirationMs,
+            )
+
+        return if (acquired) {
+            logger.debug {
+                "${application.host()}: ${executionTime.format2()}: Acquired lock for ${task.name} - $concurrencyIndex"
+            }
+            lockKey
+        } else {
+            logger.debug {
+                "${application.host()}: ${executionTime.format2()}: Failed to acquire lock for ${task.name} - $concurrencyIndex"
+            }
+            null
+        }
+    }
+}
+
+/**
+ * Common implementation for key-value based task locks.
+ * Uses a value class for efficient memory representation.
+ *
+ * The lock key format is: `taskName-***-concurrencyIndex-***-executionTime`
+ */
+@JvmInline
+public value class KeyValueTaskLock private constructor(
+    /**
+     * Unique lock key: `taskName-***-concurrencyIndex-***-executionTime`
+     */
+    public val value: String,
+) : TaskLock {
+    public companion object {
+        private const val DELIMITER = "-***-"
+
+        public fun create(
+            task: Task,
+            concurrencyIndex: Int,
+            executionTime: DateTime,
+        ): KeyValueTaskLock =
+            KeyValueTaskLock(
+                "${task.name.replace(DELIMITER, "_")}$DELIMITER$concurrencyIndex$DELIMITER${executionTime.format2()}",
+            )
+    }
+
+    override val name: String
+        get() = value.split(DELIMITER, limit = 3)[0]
+
+    override val concurrencyIndex: Int
+        get() = value.split(DELIMITER, limit = 3)[1].toInt()
+}
+
+@TaskSchedulingDsl
+public abstract class KeyValueTaskLockManagerConfiguration : TaskLockManagerConfiguration()

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/jvmTest/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManagerTest.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-core/src/jvmTest/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManagerTest.kt
@@ -1,0 +1,15 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.inmemory
+
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingPluginTest
+
+class InMemoryLockManagerTest : TaskSchedulingPluginTest() {
+    override suspend fun clean() {}
+
+    init {
+        context("in-memory lock manager") {
+            testTaskScheduling {
+                inMemory()
+            }
+        }
+    }
+}

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/build.gradle.kts
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/build.gradle.kts
@@ -1,32 +1,24 @@
 import io.github.flaxoos.ktor.commonMainDependencies
+import io.github.flaxoos.ktor.extensions.targetJvm
 import io.github.flaxoos.ktor.extensions.targetNative
 import io.github.flaxoos.ktor.jvmTestDependencies
 
 plugins {
     id("ktor-server-plugin-conventions")
-    kotlin("plugin.serialization") version
-        libs.versions.kotlin
-            .asProvider()
-            .get()
 }
 
 kotlin {
     explicitApi()
+    targetJvm(project)
     targetNative()
     sourceSets {
         commonMainDependencies {
-            api(libs.krontab)
+            api(projects.common)
+            api(projects.ktorServerTaskScheduling.ktorServerTaskSchedulingCore)
         }
         jvmTestDependencies {
             implementation(projects.ktorServerTaskScheduling.ktorServerTaskSchedulingCore.test)
-        }
-    }
-}
-
-koverReport {
-    defaults {
-        verify {
-            onCheck = false
+            implementation(libs.microutils.logging)
         }
     }
 }

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManager.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/src/commonMain/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManager.kt
@@ -1,0 +1,239 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.inmemory
+
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingConfiguration
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingDsl
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.TaskManagerConfiguration.TaskManagerName.Companion.toTaskManagerName
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueStore
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueTaskLockManager
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.keyvalue.KeyValueTaskLockManagerConfiguration
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.Application
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.datetime.Clock
+import kotlin.random.Random
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * An in-memory implementation of [KeyValueTaskLockManager].
+ *
+ * This implementation is suitable for single-instance deployments where distributed locking
+ * is not required. All locks are stored in memory and will be lost on application restart.
+ *
+ * **Important**: This manager provides locking within a single JVM/process across all
+ * InMemoryLockManager instances. It does NOT provide distributed locking across separate
+ * JVM processes or machines.
+ *
+ * @property name The name of the task manager
+ * @property application The Ktor application instance
+ * @property lockExpirationMs Lock expiration time in milliseconds. Locks older than this
+ *           duration will be considered expired and can be re-acquired.
+ * @property maxSize Maximum number of entries allowed in memory before forced cleanup.
+ *           Default: 10,000 entries
+ * @property cleanupProbability Probability (0-100) of triggering cleanup on each setIfNotExist call.
+ *           Higher values = more frequent cleanup but slightly slower performance. Default: 10 (10%)
+ */
+public class InMemoryLockManager(
+    override val name: TaskManagerConfiguration.TaskManagerName,
+    override val application: Application,
+    lockExpirationMs: Long,
+    maxSize: Int = 10_000,
+    cleanupProbability: Int = 10,
+) : KeyValueTaskLockManager(lockExpirationMs) {
+    override val store: KeyValueStore = InMemoryKeyValueStore(maxSize, cleanupProbability)
+
+    override fun close() {
+        val kvStore = store as InMemoryKeyValueStore
+        logger.debug { "Closing InMemoryLockManager, clearing ${kvStore.size()} locks" }
+        kvStore.clear()
+    }
+}
+
+/**
+ * Configuration for [InMemoryLockManager]
+ */
+@TaskSchedulingDsl
+public class InMemoryLockManagerConfiguration : KeyValueTaskLockManagerConfiguration() {
+    /**
+     * Lock expiration time in milliseconds.
+     * Locks older than this duration will be considered expired and can be re-acquired.
+     */
+    public var lockExpirationMs: Long = 100
+
+    /**
+     * Maximum number of entries allowed in memory before forced cleanup.
+     * Default: 10,000 entries
+     */
+    public var maxSize: Int = 10_000
+
+    /**
+     * Probability (0-100) of triggering cleanup on each setIfNotExist call.
+     * Higher values = more frequent cleanup but slightly slower performance.
+     * Default: 10 (10% of calls trigger cleanup)
+     */
+    public var cleanupProbability: Int = 10
+
+    override fun createTaskManager(application: Application): InMemoryLockManager =
+        InMemoryLockManager(
+            name = name.toTaskManagerName(),
+            application = application,
+            lockExpirationMs = lockExpirationMs,
+            maxSize = maxSize,
+            cleanupProbability = cleanupProbability,
+        )
+}
+
+/**
+ * Add an [InMemoryLockManager] to the task scheduling configuration.
+ *
+ * This provides an in-memory task lock manager suitable for single-instance deployments
+ * where distributed locking is not required.
+ *
+ * **Important**: This manager provides locking within a single JVM/process across all
+ * InMemoryLockManager instances. It does NOT provide distributed locking across separate
+ * JVM processes or machines.
+ *
+ * **Memory Management**: The in-memory store uses probabilistic cleanup to prevent memory leaks
+ * from expired lock entries. Cleanup is triggered:
+ * - Always when the number of entries exceeds `maxSize`
+ * - Probabilistically on `cleanupProbability`% of lock acquisition attempts
+ *
+ * Example usage:
+ * ```kotlin
+ * install(TaskScheduling) {
+ *     inMemory {
+ *         lockExpirationMs = 60_000      // Locks expire after 60 seconds
+ *         maxSize = 10_000               // Trigger cleanup if > 10K entries
+ *         cleanupProbability = 10        // 10% chance of cleanup per call
+ *     }
+ *
+ *     task {
+ *         name = "my-task"
+ *         kronSchedule = { seconds { 0 every 30 } }
+ *         task = { executionTime ->
+ *             // Task logic here
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param name The name of the task manager. If not provided, this will be the default task manager.
+ *             Only one default task manager is allowed.
+ * @param config Configuration block for the in-memory lock manager
+ */
+@TaskSchedulingDsl
+public fun TaskSchedulingConfiguration.inMemory(
+    name: String? = null,
+    config: InMemoryLockManagerConfiguration.() -> Unit = {},
+) {
+    this.addTaskManager(
+        InMemoryLockManagerConfiguration().apply {
+            config()
+            this.name = name
+        },
+    )
+}
+
+/**
+ * In-memory implementation of [KeyValueStore] using a ConcurrentMap.
+ *
+ * This implementation provides SET-if-not-exists semantics with TTL support
+ * using a retry loop and manual expiration checking. The storage is shared
+ * across all instances within the same JVM process.
+ *
+ * **TTL and Memory Management:**
+ * - Expired entries are removed lazily when accessed (opportunistic cleanup)
+ * - Probabilistic cleanup runs on a percentage of [setIfNotExist] calls
+ * - Hard limit cleanup triggers when [maxSize] is exceeded
+ *
+ * @property maxSize Maximum entries before forced cleanup (default: 10,000)
+ * @property cleanupProbability Percentage chance (0-100) of cleanup per call (default: 10)
+ */
+internal class InMemoryKeyValueStore(
+    private val maxSize: Int = 10_000,
+    private val cleanupProbability: Int = 10,
+) : KeyValueStore {
+    private companion object {
+        // Shared storage across all InMemoryKeyValueStore instances in the same JVM
+        private val storage = ConcurrentMap<String, ExpiringValue>()
+    }
+
+    /**
+     * Internal wrapper to store values with expiration time
+     */
+    private data class ExpiringValue(
+        val value: String,
+        val expiresAtMs: Long,
+    )
+
+    override suspend fun setIfNotExist(
+        key: String,
+        value: String,
+        ttlMs: Long,
+    ): Boolean {
+        // Cleanup strategy: size-based + probabilistic
+        when {
+            // Hard limit - always cleanup if exceeded
+            storage.size > maxSize -> cleanupExpired()
+
+            // Probabilistic cleanup - amortize cost across calls
+            cleanupProbability > 0 && Random.nextInt(100) < cleanupProbability ->
+                cleanupExpired()
+        }
+
+        val now = Clock.System.now().toEpochMilliseconds()
+        val expiresAt = now + ttlMs
+
+        while (true) {
+            var wasCreated = false
+            val expiringValue = ExpiringValue(value, expiresAt)
+
+            val existing =
+                storage.computeIfAbsent(key) {
+                    wasCreated = true
+                    expiringValue
+                }
+
+            when {
+                // Successfully created new entry
+                wasCreated -> return true
+
+                // Entry exists but expired - try to replace atomically
+                now >= existing.expiresAtMs -> {
+                    storage.remove(key, existing)
+                    continue
+                }
+
+                // Entry exists and valid - failed to acquire
+                else -> return false
+            }
+        }
+    }
+
+    /**
+     * Remove all expired entries from storage.
+     * Scans entire map - O(n) operation.
+     */
+    private fun cleanupExpired() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val iterator = storage.entries.iterator()
+
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (now >= entry.value.expiresAtMs) {
+                iterator.remove()
+            }
+        }
+    }
+
+    /**
+     * Clear all entries from the store
+     */
+    fun clear(): Unit = storage.clear()
+
+    /**
+     * Get the number of entries in the store
+     */
+    fun size(): Int = storage.size
+}

--- a/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/src/jvmTest/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManagerTest.kt
+++ b/ktor-server-task-scheduling/ktor-server-task-scheduling-inmemory/src/jvmTest/kotlin/io/github/flaxoos/ktor/server/plugins/taskscheduling/managers/lock/inmemory/InMemoryLockManagerTest.kt
@@ -1,0 +1,15 @@
+package io.github.flaxoos.ktor.server.plugins.taskscheduling.managers.lock.inmemory
+
+import io.github.flaxoos.ktor.server.plugins.taskscheduling.TaskSchedulingPluginTest
+
+class InMemoryLockManagerTest : TaskSchedulingPluginTest() {
+    override suspend fun clean() {}
+
+    init {
+        context("in-memory lock manager") {
+            testTaskScheduling {
+                inMemory()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is an implementation of [this](https://github.com/Flaxoos/extra-ktor-plugins/issues/98)  feature request
- created abstraction for key value task managers
- refactored redis task manager to use said abstraction

Add new in-memory lock manager module for single-instance deployments:
 - Create InMemoryLockManager with optional lock expiration support
 - Implement thread-safe lock acquisition using ConcurrentMap
 - Provide DSL configuration via inMemory() extension function
 - Include basic test suite extending TaskSchedulingPluginTest
 - Integrate module into task-scheduling parent module
